### PR TITLE
Moved socket binding to ensure success before starting event loop

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -148,7 +148,10 @@ fn main() {
         actor_id: actor_id,
         max_io_threads: max_io_threads,
     };
-    server::run(server_options);
+    let run_finished = server::run(server_options);
+    if let Some(err) = run_finished.err() {
+        error!("IO Error: {}", err);
+    }
     info!("Shutdown server");
 }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -15,7 +15,7 @@ use event::ActorId;
 use futures::sync::mpsc::unbounded;
 use std::path::PathBuf;
 use std::net::{SocketAddr, Ipv4Addr, SocketAddrV4};
-use std::io::{self, Write};
+use std::io;
 use engine;
 
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -65,18 +65,12 @@ pub struct ServerOptions {
 }
 
 
-pub fn run(options: ServerOptions) {
+pub fn run(options: ServerOptions) -> io::Result<()> {
 
     let server_port = options.port;
     let address: SocketAddr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), server_port));
 
-    let listener = match ::std::net::TcpListener::bind(address) {
-        Ok(listener) => listener,
-        Err(e) => {
-            writeln!(&mut io::stderr(), "Error binding to socket: {}", e).unwrap();
-            return;
-        }
-    };
+    let listener = ::std::net::TcpListener::bind(address)?;
 
     let (join_handle, mut event_loop_handles) = self::event_loops::spawn_event_loop_threads(options.max_io_threads).unwrap();
 
@@ -126,5 +120,7 @@ pub fn run(options: ServerOptions) {
     });
 
     join_handle.join();
+
+    Ok(())
 }
 


### PR DESCRIPTION
This fixes #2.

I wasn't sure how to stop the event loop from within, so I changed the run method to first attempt to bind to the socket, then pass that listener to the handler within the futures.

