### PR TITLE
async consumer can be stopped mid consume operation

### DIFF
--- a/flo-client-lib/src/async/mod.rs
+++ b/flo-client-lib/src/async/mod.rs
@@ -163,6 +163,19 @@ pub enum ErrorType {
     Server(ErrorMessage)
 }
 
+impl ErrorType {
+    pub fn unexpected_message(expected: &'static str, actual: ProtocolMessage) -> ErrorType {
+        let msg = format!("Unexpected message: {:?}, expected: {}", actual, expected);
+        io::Error::new(io::ErrorKind::InvalidData, msg).into()
+    }
+}
+
+impl From<ErrorMessage> for ErrorType {
+    fn from(message: ErrorMessage) -> Self {
+        ErrorType::Server(message)
+    }
+}
+
 impl From<io::Error> for ErrorType {
     fn from(io_err: io::Error) -> Self {
         ErrorType::Io(io_err)

--- a/flo-client-lib/src/async/ops/handshake.rs
+++ b/flo-client-lib/src/async/ops/handshake.rs
@@ -66,11 +66,9 @@ fn result_from_response<D: Debug>(response: ProtocolMessage, mut connection: Asy
         }
         other @ _ => {
             // bad, bad, not good
-            let err_msg = format!("Received unexpected message, expected: StreamStatus message, got: {:?}", other);
-            error!("{}", err_msg);
             Err(HandshakeError {
                 message: "Unexpected message from server",
-                error_type: ErrorType::Io(io::Error::new(io::ErrorKind::InvalidData, err_msg))
+                error_type: ErrorType::unexpected_message("StreamStatus", other)
             })
         }
     }

--- a/flo-client-lib/src/sync/mod.rs
+++ b/flo-client-lib/src/sync/mod.rs
@@ -25,7 +25,8 @@ fn run_future<T, E, F: Future<Item=T, Error=E>>(future: F) -> Result<T, E> {
     })
 }
 
-
+/// Used to perform synchronous operations with a flo server. This type just wraps an `AsyncConnection` and uses a thread
+/// local `tokio_core::reactor::Core` to drive all operations to completion in a synchronous fashion.
 pub struct SyncConnection<D: Debug> {
     async_connection: Option<AsyncConnection<D>>,
 }
@@ -40,6 +41,8 @@ impl <D: Debug> From<AsyncConnection<D>> for SyncConnection<D> {
 
 impl <D: Debug + 'static> SyncConnection<D> {
 
+    /// The same as `connect`, except that the address will resolved from the given `address` string. This allows connecting
+    /// using a host name instead of an IP address.
     pub fn connect_from_str<N, C>(address: &str, client_name: N, codec: C, consume_batch_size: Option<u32>) -> Result<SyncConnection<D>, HandshakeError>
             where N: Into<String>, C: EventCodec<EventData=D> + 'static {
         REACTOR.with(|core| {
@@ -64,6 +67,8 @@ impl <D: Debug + 'static> SyncConnection<D> {
         })
     }
 
+    /// Attempts to connect to the given `address` and then initiates the handshake with the server. If successful, the
+    /// returned connection will be ready to use for any operations.
     pub fn connect<A, N, C>(address: A, client_name: N, codec: C, consume_batch_size: Option<u32>) -> Result<SyncConnection<D>, HandshakeError>
                     where A: Into<SocketAddr>, N: Into<String>, C: EventCodec<EventData=D> + 'static {
 
@@ -76,9 +81,12 @@ impl <D: Debug + 'static> SyncConnection<D> {
         result.map(|async_conn| async_conn.into())
     }
 
-    pub fn produce(&mut self, event: EventToProduce<D>) -> Result<FloEventId, ErrorType> {
+    /// A convenience method for producing an event, similar to `produce_to`. This allows callers to implement
+    /// `Into<EventToProduce<D>>` for any type to allow it to be used to produce an event. See the docs for
+    /// `produce_to` for more details.
+    pub fn produce<T: Into<EventToProduce<D>>>(&mut self, event: T) -> Result<FloEventId, ErrorType> {
         let conn = self.async_connection.take().unwrap();
-        let result = run_future(conn.produce(event));
+        let result = run_future(conn.produce(event.into()));
         match result {
             Ok((id, conn)) => {
                 self.async_connection = Some(conn);
@@ -91,6 +99,10 @@ impl <D: Debug + 'static> SyncConnection<D> {
         }
     }
 
+    /// Produces an event onto the given `partition` with the given `namespace`, `parent_id`, and `data`. Returns the id of
+    /// the event once it is successfully persisted, otherwise an error. If this method returns sucessfully, the returned
+    /// `FloEventId` will always refer to the same event and is guaranteed to be stable. That is, it will never be re-used to
+    /// refer to any other event in the event stream, even if the produce event expires and is no longer part of the event stream.
     pub fn produce_to<N: Into<String>>(&mut self, partition: ActorId, namespace: N, parent_id: Option<FloEventId>, data: D) -> Result<FloEventId, ErrorType> {
         let to_produce = EventToProduce {
             partition,
@@ -101,6 +113,35 @@ impl <D: Debug + 'static> SyncConnection<D> {
         self.produce(to_produce)
     }
 
+    /// Use this connection to consume events from the server. The returned value implements `Iterator`
+    /// where the associated `Item` is `Result<Event<D>, ErrorType>`.
+    ///
+    /// ### `namespace`
+    ///
+    /// Only events matching the given `namespace` glob will be returned. The glob pattern will be parsed by the [glob](https://crates.io/crates/glob)
+    /// crate, so that is what determines what is/isn't a valid pattern. More documentation is surly needed on this, so please contribute :)
+    ///
+    /// ### `version_vector`
+    ///
+    /// The `version_vector` argument determines the starting point. Only events from the partitions included in the version vector will
+    /// be sent. For example, given an event stream with 5 partitions, if the version vector only includes entries for partitions 1, 3, and 5,
+    /// then only events from those partitions will be read. Also, only events _after_ each `EventCounter` mentioned in the version vector will
+    /// be sent. For instance, if the version vector includes an entry for `partition: 3, event_counter: 5`, then the first event received
+    /// will be for _at least_ `partition: 3, event_counter: 6` (though it may be after that if there is no event with a counter of 6).
+    ///
+    /// ### `event_limit`
+    ///
+    /// If `Some`, this argument will determine the maximum number of events that will be received by this consume operation. After the given
+    /// number of events is reached, the server will automatically stop sending events. If this argument is `None`, then the number of events
+    /// sent by the server will be unlimited.
+    ///
+    /// ### `await_new_events`
+    ///
+    /// Determines the behavior of the consumer once it reaches the end of the stream (wherever that may be at the time). If this argument
+    /// is `false`, then the consumer will automatically be stopped by the server as soon as the end of the stream is reached. This guarantees
+    /// that the consumer will not block waiting for new events to be added to the stream. If this argument is `true`, then the `EventIterator`
+    /// will only return `None` when the `event_limit` is reached. If `await_new_events` is `true` _and_ `event_limit` is `None`, then the
+    /// `EventIterator` will _never_ return `None`.
     pub fn into_consumer<N: Into<String>>(mut self, namespace: N, version_vector: &VersionVector, event_limit: Option<u64>, await_new_events: bool) -> EventIterator<D> {
         let connection = self.async_connection.take().unwrap();
         let consume = connection.consume(namespace, version_vector, event_limit, await_new_events);
@@ -110,6 +151,8 @@ impl <D: Debug + 'static> SyncConnection<D> {
         }
     }
 
+    /// Returns information on the event stream associated with this connection. Will return `None` if the handshake with the server has not
+    /// been performed yet.
     pub fn current_stream(&self) -> Option<&CurrentStreamState> {
         self.async_connection.as_ref().and_then(|conn| conn.current_stream())
     }

--- a/flo-server/src/engine/api/mod.rs
+++ b/flo-server/src/engine/api/mod.rs
@@ -56,7 +56,7 @@ impl ClientMessage {
 
             m @ ProtocolMessage::AckEvent(_) => consumer_message(connection_id, m),
             m @ ProtocolMessage::StartConsuming(_) => consumer_message(connection_id, m),
-            m @ ProtocolMessage::StopConsuming => consumer_message(connection_id, m),
+            m @ ProtocolMessage::StopConsuming(_) => consumer_message(connection_id, m),
             m @ ProtocolMessage::UpdateMarker(_) => consumer_message(connection_id, m),
             m @ ProtocolMessage::SetBatchSize(_) => consumer_message(connection_id, m),
             m @ ProtocolMessage::NextBatch => consumer_message(connection_id, m),

--- a/flo-server/src/engine/consumer/client/connection_manager.rs
+++ b/flo-server/src/engine/consumer/client/connection_manager.rs
@@ -49,7 +49,7 @@ impl <S: Sender<ProtocolMessage> + 'static> ClientConnection<S> {
             &ProtocolMessage::StartConsuming(ref start) => {
                 self.start_consuming(start, context)
             }
-            &ProtocolMessage::StopConsuming => {
+            &ProtocolMessage::StopConsuming(_) => {
                 self.state.stop_consuming()
             }
             &ProtocolMessage::AckEvent(ref ack) => {

--- a/flo-server/src/new_engine/connection_handler/connection_state.rs
+++ b/flo-server/src/new_engine/connection_handler/connection_state.rs
@@ -45,7 +45,10 @@ impl ConnectionState {
             debug!("Using consume batch size of {} for connection_id: {}", batch_size, self.connection_id);
             self.consume_batch_size = batch_size;
         }
+        self.send_stream_status(op_id)
+    }
 
+    pub fn send_stream_status(&mut self, op_id: u32) -> ConnectionHandlerResult {
         let status = create_stream_status(op_id, &self.event_stream);
         self.send_to_client(ProtocolMessage::StreamStatus(status)).map_err(|err| {
             format!("Error sending message to client: {:?}", err)

--- a/flo-server/src/new_engine/connection_handler/consumer/mod.rs
+++ b/flo-server/src/new_engine/connection_handler/consumer/mod.rs
@@ -41,7 +41,7 @@ impl ConsumerConnectionState {
     }
 
     pub fn shutdown(&mut self, connection: &mut ConnectionState) {
-        if let Some(ref mut consumer) = self.consumer_ref {
+        if let Some(ref mut consumer) = self.consumer_ref.take() {
             // tell the active consumer to stop sending events
             consumer.status_setter.set(ConsumerStatus::Stop);
 
@@ -54,6 +54,11 @@ impl ConsumerConnectionState {
                 }
             }
         }
+    }
+
+    pub fn stop_consuming(&mut self, op_id: u32, connection: &mut ConnectionState) -> ConnectionHandlerResult {
+        self.shutdown(connection);
+        connection.send_stream_status(op_id)
     }
 
     pub fn requires_poll_complete(&self) -> bool {

--- a/flo-server/src/new_engine/connection_handler/mod.rs
+++ b/flo-server/src/new_engine/connection_handler/mod.rs
@@ -127,7 +127,6 @@ mod test {
     use tokio_core::reactor::Core;
 
     use super::*;
-    use protocol::*;
     use event::ActorId;
     use new_engine::{SYSTEM_STREAM_NAME, system_stream_name};
     use new_engine::event_stream::EventStreamRef;

--- a/flo-server/src/new_engine/connection_handler/mod.rs
+++ b/flo-server/src/new_engine/connection_handler/mod.rs
@@ -59,6 +59,9 @@ impl ConnectionHandler {
             ProtocolMessage::NextBatch => {
                 consumer_state.handle_next_batch(common_state)
             }
+            ProtocolMessage::StopConsuming(op_id) => {
+                consumer_state.stop_consuming(op_id, common_state)
+            }
             _ => unimplemented!()
         }
     }
@@ -124,6 +127,7 @@ mod test {
     use tokio_core::reactor::Core;
 
     use super::*;
+    use protocol::*;
     use event::ActorId;
     use new_engine::{SYSTEM_STREAM_NAME, system_stream_name};
     use new_engine::event_stream::EventStreamRef;


### PR DESCRIPTION
Can now explicitly stop a consumer in the middle of a consume operation. This is not required for consumers that have reached their limit of events or that have stopped at the end of a stream. It is intended to be used when you want to stop a consumer early and re-use the connection.