### PR TITLE
Generic protocol

### DIFF
--- a/flo-client-lib/src/async/mod.rs
+++ b/flo-client-lib/src/async/mod.rs
@@ -16,7 +16,7 @@ use tokio_core::io::Io;
 use futures::{Stream, Sink};
 
 use protocol::{ProtocolMessage, ErrorMessage};
-use event::{FloEventId, ActorId, VersionVector};
+use event::{FloEventId, ActorId, VersionVector, OwnedFloEvent};
 use codec::EventCodec;
 use self::recv::MessageRecvStream;
 use self::send::MessageSendSink;
@@ -25,8 +25,8 @@ use self::ops::{ProduceOne, ProduceAll, EventToProduce, Consume, Handshake};
 
 pub use self::tcp_connect::{tcp_connect, tcp_connect_with, AsyncTcpClientConnect};
 pub use self::current_stream_state::{CurrentStreamState, PartitionState};
-pub type MessageSender = Box<Sink<SinkItem=ProtocolMessage, SinkError=io::Error>>;
-pub type MessageReceiver = Box<Stream<Item=ProtocolMessage, Error=io::Error>>;
+pub type MessageSender = Box<Sink<SinkItem=ProtocolMessage<OwnedFloEvent>, SinkError=io::Error>>;
+pub type MessageReceiver = Box<Stream<Item=ProtocolMessage<OwnedFloEvent>, Error=io::Error>>;
 
 pub const DEFAULT_RECV_BATCH_SIZE: u32 = 1000;
 

--- a/flo-client-lib/src/async/ops/consume.rs
+++ b/flo-client-lib/src/async/ops/consume.rs
@@ -5,7 +5,7 @@ use std::io;
 use futures::{Future, Async, Poll, Stream};
 
 use event::VersionVector;
-use protocol::{ProtocolMessage, NewConsumerStart, CONSUME_UNLIMITED, RecvEvent};
+use protocol::{ProtocolMessage, NewConsumerStart, CONSUME_UNLIMITED, OwnedFloEvent};
 use async::{AsyncConnection, ErrorType};
 use async::ops::{SendMessage, SendError, AwaitResponse, AwaitResponseError, RequestResponse};
 use ::Event;
@@ -283,7 +283,7 @@ impl <D: Debug> EventReceiver<D> {
         Ok(Async::Ready(PollSuccess::NewState(new_state)))
     }
 
-    fn convert_received(&mut self, event: RecvEvent, op_id: u32) -> PollState<D> {
+    fn convert_received(&mut self, event: OwnedFloEvent, op_id: u32) -> PollState<D> {
         let event = event.into_owned();
         let event_id = event.id;
         let converted = {

--- a/flo-client-lib/src/async/ops/handshake.rs
+++ b/flo-client-lib/src/async/ops/handshake.rs
@@ -5,7 +5,7 @@ use std::io;
 use futures::{Future, Async, Poll};
 
 use protocol::{ProtocolMessage, ClientAnnounce};
-use async::{AsyncConnection, ErrorType};
+use async::{AsyncConnection, ErrorType, ClientProtocolMessage};
 use async::ops::{RequestResponse, RequestResponseError};
 
 const PROTOCOL_VERSION: u32 = 1;
@@ -48,7 +48,7 @@ impl <D: Debug> Into<AsyncConnection<D>> for Handshake<D> {
     }
 }
 
-fn result_from_response<D: Debug>(response: ProtocolMessage, mut connection: AsyncConnection<D>) -> Poll<AsyncConnection<D>, HandshakeError> {
+fn result_from_response<D: Debug>(response: ClientProtocolMessage, mut connection: AsyncConnection<D>) -> Poll<AsyncConnection<D>, HandshakeError> {
     debug!("Received Response: {:?}", response);
 
     match response {

--- a/flo-client-lib/src/async/ops/produce.rs
+++ b/flo-client-lib/src/async/ops/produce.rs
@@ -5,7 +5,7 @@ use futures::{Future, Poll, Async};
 
 use event::{FloEventId, ActorId};
 use protocol::{ProtocolMessage, ProduceEvent};
-use async::{AsyncConnection, ErrorType};
+use async::{AsyncConnection, ErrorType, ClientProtocolMessage};
 use async::ops::{RequestResponse, RequestResponseError};
 
 /// An operation that produces a single event on an event stream and waits for it to be acknowledged. This future will
@@ -57,7 +57,7 @@ impl <D: Debug> ProduceOne<D> {
     }
 
 
-    fn response_received(connection: AsyncConnection<D>, response: ProtocolMessage) -> Result<Async<(FloEventId, AsyncConnection<D>)>, ProduceErr<D>> {
+    fn response_received(connection: AsyncConnection<D>, response: ClientProtocolMessage) -> Result<Async<(FloEventId, AsyncConnection<D>)>, ProduceErr<D>> {
         match response {
             ProtocolMessage::AckEvent(ack) => {
                 Ok(Async::Ready((ack.event_id, connection)))

--- a/flo-client-lib/src/async/ops/request_response.rs
+++ b/flo-client-lib/src/async/ops/request_response.rs
@@ -4,8 +4,7 @@ use std::fmt::Debug;
 
 use futures::{Future, Async, Poll};
 
-use protocol::{ProtocolMessage};
-use async::{AsyncConnection};
+use async::{AsyncConnection, ClientProtocolMessage};
 use async::ops::{SendMessage, SendError, AwaitResponse, AwaitResponseError};
 
 #[derive(Debug)]
@@ -15,7 +14,7 @@ pub struct RequestResponse<D: Debug> {
 }
 
 impl <D: Debug> RequestResponse<D> {
-    pub fn new(connection: AsyncConnection<D>, request: ProtocolMessage) -> RequestResponse<D> {
+    pub fn new(connection: AsyncConnection<D>, request: ClientProtocolMessage) -> RequestResponse<D> {
         let op_id = request.get_op_id();
         debug_assert_ne!(op_id, 0);
         RequestResponse {
@@ -26,7 +25,7 @@ impl <D: Debug> RequestResponse<D> {
 }
 
 impl <D: Debug> Future for RequestResponse<D> {
-    type Item = (ProtocolMessage, AsyncConnection<D>);
+    type Item = (ClientProtocolMessage, AsyncConnection<D>);
     type Error = RequestResponseError<D>;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {

--- a/flo-client-lib/src/async/ops/send_message.rs
+++ b/flo-client-lib/src/async/ops/send_message.rs
@@ -4,8 +4,7 @@ use std::io;
 use futures::{Sink, Future, Async, Poll};
 use futures::sink::Send;
 
-use protocol::ProtocolMessage;
-use async::{AsyncConnection, MessageSender};
+use async::{AsyncConnection, MessageSender, ClientProtocolMessage};
 
 pub struct SendMessage<D: Debug> {
     connection: Option<AsyncConnection<D>>,
@@ -19,7 +18,7 @@ impl <D: Debug> Debug for SendMessage<D> {
 }
 
 impl <D: Debug> SendMessage<D> {
-    pub fn new(mut connection: AsyncConnection<D>, message: ProtocolMessage) -> SendMessage<D> {
+    pub fn new(mut connection: AsyncConnection<D>, message: ClientProtocolMessage) -> SendMessage<D> {
         let sender = connection.take_sender();
 
         let send = sender.send(message);

--- a/flo-client-lib/src/async/recv.rs
+++ b/flo-client-lib/src/async/recv.rs
@@ -3,13 +3,14 @@ use std::fmt::{self, Debug};
 
 use futures::{Async, Poll, Stream};
 
+use event::OwnedFloEvent;
 use protocol::{self, ProtocolMessage};
 
-pub trait MessageStream: Stream<Item=ProtocolMessage, Error=io::Error> + Debug {
+pub trait MessageStream: Stream<Item=ProtocolMessage<OwnedFloEvent>, Error=io::Error> + Debug {
 }
 
 pub struct MessageRecvStream<R: Read> {
-    message_reader: protocol::MessageStream<R>,
+    message_reader: protocol::MessageStream<R, OwnedFloEvent>,
     connected: bool
 }
 
@@ -31,7 +32,7 @@ impl <R: Read> Debug for MessageRecvStream<R> {
 }
 
 impl <R: Read> Stream for MessageRecvStream<R> {
-    type Item = ProtocolMessage;
+    type Item = ProtocolMessage<OwnedFloEvent>;
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {

--- a/flo-protocol/src/client.rs
+++ b/flo-protocol/src/client.rs
@@ -1011,12 +1011,8 @@ mod test {
             namespace: "/foo/bar".to_owned(),
             data: vec![9; 99],
         };
-        let message = ProtocolMessage::ReceiveEvent(RecvEvent::Owned(event.clone()));
+        let message = ProtocolMessage::ReceiveEvent(event.clone());
         let result = serde_with_body(&message, true);
-        assert_eq!(message, result);
-
-        let arc_message = ProtocolMessage::ReceiveEvent(RecvEvent::Ref(Arc::new(event.clone())));
-        let result = serde_with_body(&arc_message, true);
         assert_eq!(message, result);
     }
 

--- a/flo-server/src/engine/connection_handler/connection_state.rs
+++ b/flo-server/src/engine/connection_handler/connection_state.rs
@@ -3,7 +3,7 @@ use tokio_core::reactor::Handle;
 
 use protocol::*;
 
-use engine::{ConnectionId, ClientSender, EngineRef};
+use engine::{ConnectionId, ClientSender, EngineRef, SendProtocolMessage};
 use engine::event_stream::EventStreamRef;
 
 use super::ConnectionHandlerResult;
@@ -84,7 +84,7 @@ impl ConnectionState {
         }
     }
 
-    pub fn send_to_client(&self, message: ProtocolMessage) -> ConnectionHandlerResult {
+    pub fn send_to_client(&self, message: SendProtocolMessage) -> ConnectionHandlerResult {
         self.client_sender.unbounded_send(message).map_err(|e| {
             format!("Error sending outgoing message for connection_id: {}, message: {:?}", self.connection_id, e.into_inner())
         })

--- a/flo-server/src/engine/event_stream/partition/segment/persistent_event.rs
+++ b/flo-server/src/engine/event_stream/partition/segment/persistent_event.rs
@@ -111,6 +111,16 @@ impl PersistentEvent {
     }
 }
 
+impl PartialEq for PersistentEvent {
+    fn eq(&self, other: &PersistentEvent) -> bool {
+        self.id() == other.id() &&
+                self.parent_id() == other.parent_id() &&
+                self.namespace() == other.namespace() &&
+                self.timestamp() == other.timestamp() &&
+                self.data() == other.data()
+    }
+}
+
 impl FloEvent for PersistentEvent {
     fn id(&self) -> &FloEventId {
         &self.id

--- a/flo-server/src/engine/mod.rs
+++ b/flo-server/src/engine/mod.rs
@@ -16,8 +16,9 @@ pub use self::connection_handler::{ConnectionHandler, ConnectionHandlerResult};
 
 pub type ConnectionId = usize;
 
-pub type ClientSender = ::futures::sync::mpsc::UnboundedSender<ProtocolMessage>;
-pub type ClientReceiver = ::futures::sync::mpsc::UnboundedReceiver<ProtocolMessage>;
+use engine::event_stream::partition::segment::PersistentEvent;
+pub type ClientSender = ::futures::sync::mpsc::UnboundedSender<ProtocolMessage<PersistentEvent>>;
+pub type ClientReceiver = ::futures::sync::mpsc::UnboundedReceiver<ProtocolMessage<OwnedFloEvent>>;
 
 pub fn create_client_channels() -> (ClientSender, ClientReceiver) {
     ::futures::sync::mpsc::unbounded()

--- a/flo-server/src/engine/mod.rs
+++ b/flo-server/src/engine/mod.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicUsize};
 
 use protocol::ProtocolMessage;
-
+use event::OwnedFloEvent;
 use self::event_stream::EventStreamRef;
 
 pub use self::controller::{ControllerOptions, start_controller};
@@ -16,9 +16,15 @@ pub use self::connection_handler::{ConnectionHandler, ConnectionHandlerResult};
 
 pub type ConnectionId = usize;
 
-use engine::event_stream::partition::segment::PersistentEvent;
-pub type ClientSender = ::futures::sync::mpsc::UnboundedSender<ProtocolMessage<PersistentEvent>>;
-pub type ClientReceiver = ::futures::sync::mpsc::UnboundedReceiver<ProtocolMessage<OwnedFloEvent>>;
+use engine::event_stream::partition::PersistentEvent;
+
+/// Thy type of messages that are received from clients
+pub type ReceivedProtocolMessage = ProtocolMessage<OwnedFloEvent>;
+/// The type of messages that are sent to client
+pub type SendProtocolMessage = ProtocolMessage<PersistentEvent>;
+
+pub type ClientSender = ::futures::sync::mpsc::UnboundedSender<SendProtocolMessage>;
+pub type ClientReceiver = ::futures::sync::mpsc::UnboundedReceiver<SendProtocolMessage>;
 
 pub fn create_client_channels() -> (ClientSender, ClientReceiver) {
     ::futures::sync::mpsc::unbounded()

--- a/flo-server/src/server/flo_io/client_message_stream.rs
+++ b/flo-server/src/server/flo_io/client_message_stream.rs
@@ -3,15 +3,16 @@ use std::io::{self, Read};
 use futures::{Poll, Async};
 use futures::stream::Stream;
 
-use engine::ConnectionId;
-use protocol::{MessageStream, ProtocolMessage};
+use event::OwnedFloEvent;
+use engine::{ConnectionId, ReceivedProtocolMessage};
+use protocol::MessageStream;
 
 
 /// New implementation, that just provides a `Stream` of `ProtocolMessage`s.
 /// Theres a lot of duplicated code here, at the moment, until `ClientMessageStream` is removed
 pub struct ProtocolMessageStream<R: Read> {
     connection_id: ConnectionId,
-    message_reader: MessageStream<R>,
+    message_reader: MessageStream<R, OwnedFloEvent>,
     connected: bool
 }
 
@@ -26,7 +27,7 @@ impl <R: Read> ProtocolMessageStream<R> {
 }
 
 impl <R: Read> Stream for ProtocolMessageStream<R> {
-    type Item = ProtocolMessage;
+    type Item = ReceivedProtocolMessage;
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {

--- a/flo-server/src/server/flo_io/server_message_stream.rs
+++ b/flo-server/src/server/flo_io/server_message_stream.rs
@@ -8,21 +8,22 @@ use futures::{Future, Poll};
 use tokio_core::io::WriteHalf;
 use tokio_core::net::TcpStream;
 
-use engine::ConnectionId;
-use protocol::{ProtocolMessage, MessageWriter};
+use engine::{ConnectionId, SendProtocolMessage};
+use engine::event_stream::partition::PersistentEvent;
+use protocol::MessageWriter;
 
 #[allow(deprecated)]
 pub type ServerWriteStream = WriteHalf<TcpStream>;
 
 pub struct ServerMessageStream {
     connection_id: ConnectionId,
-    server_receiver: UnboundedReceiver<ProtocolMessage>,
-    current_message: Option<MessageWriter<'static>>,
+    server_receiver: UnboundedReceiver<SendProtocolMessage>,
+    current_message: Option<MessageWriter<PersistentEvent>>,
     tcp_stream: ServerWriteStream,
 }
 
 impl ServerMessageStream {
-    pub fn new(connection_id: ConnectionId, server_rx: UnboundedReceiver<ProtocolMessage>, tcp_stream: ServerWriteStream) -> ServerMessageStream {
+    pub fn new(connection_id: ConnectionId, server_rx: UnboundedReceiver<SendProtocolMessage>, tcp_stream: ServerWriteStream) -> ServerMessageStream {
         ServerMessageStream {
             connection_id: connection_id,
             server_receiver: server_rx,

--- a/flo-server/tests/embedded_tests.rs
+++ b/flo-server/tests/embedded_tests.rs
@@ -123,7 +123,7 @@ fn oldest_events_are_dropped_from_beginning_of_stream_after_time_based_expiratio
         }
 
         let start_time = ::std::time::Instant::now();
-        let until_all_expired = (retention_duration + segment_duration).to_std().unwrap();
+        let until_all_expired = (retention_duration + segment_duration + chrono::Duration::milliseconds(250)).to_std().unwrap();
         let mut first_event_id = FloEventId::new(1, 0);
         let mut vv = VersionVector::new();
         vv.set(first_event_id);


### PR DESCRIPTION
Adds a generic type parameter to `ProtocolMessage` for the type of event in the `RecvEvent` message.

This allows the server to send `PersistentEvent`s directly without copying the data. Unfortunately, there's still a copy required for embedded clients to facilitate the conversion from `ProtocolMessage<PersistentEvent>` into `ProtocolMessage<OwnedFloEvent>`. The solution to that is ultimately to make the `AsyncConnection` also generic over received event types. That's not hard, but I would like to figure out a good way to do it without exposing the generic type in the public api of the client. For now, I'm just considering that a problem for another time.